### PR TITLE
Fix: Missing deleteLocalData in TorrentRemoveRequestParam.build

### DIFF
--- a/lib/src/client.dart
+++ b/lib/src/client.dart
@@ -795,7 +795,7 @@ class _TransmissionRpcClient implements TransmissionRpcClient {
   Future<TorrentRemoveResponse> torrentRemove(TorrentIds<TorrentId> ids,
           {bool? deleteLocalData, RpcTag? tag, int? timeout}) =>
       checkAndCallApi(
-        TorrentRemoveRequestParam.build(version: serverRpcVersion, ids: ids),
+        TorrentRemoveRequestParam.build(version: serverRpcVersion, ids: ids, deleteLocalData: deleteLocalData),
         method: TransmissionRpcMethod.torrentRemove,
         tag: tag,
         timeout: timeout,


### PR DESCRIPTION
The deleteLocalData field was missing from the TorrentRemoveRequestParam construction. As a result, it was not possible to send a request that also deleted the downloaded content along with the torrent entry.